### PR TITLE
fix issue with courses without a course_code

### DIFF
--- a/courses/utils.py
+++ b/courses/utils.py
@@ -49,9 +49,12 @@ def get_canvas_course(course_code=None, term_name=None, canvas_id=None):
     # TODO: much more info is available in the Canvas API
     # so we can add some more columns to the database
     for canvas_course in canvas_courses:
-        if (canvas_course.course_code == course_code 
-                and canvas_course.term["name"] == term_name):
-            return canvas_course
+        try:
+            if (canvas_course.course_code == course_code 
+                    and canvas_course.term["name"] == term_name):
+                return canvas_course
+        except:
+            pass
     return None
     
 


### PR DESCRIPTION
When trying add a new course, the `get_canvas_course` function tries to match the `course_code` attribute of a course with the string literal `course_code`. Since not every course has such an attribute, we have implemented a try statement which just skips over such courses. 